### PR TITLE
fix: replace `backticks` with single quotes in PR title

### DIFF
--- a/src/validate-pull-request.js
+++ b/src/validate-pull-request.js
@@ -29,6 +29,9 @@ async function validatePullRequest(preset, title, body = '', prInfo) {
 	if (/".+"/g.test(title)) {
 		title = title.replace(/"/g, '\'');
 	}
+	if (/`/g.test(title)) {
+		title = title.replace(/`/g, '\'')
+	}
 	if (body){
 		body = splitBodyBySeparator(body);
 		body = body.replace(/`/gm, '\\`');


### PR DESCRIPTION
https://make.atlassian.net/browse/DEX-532
this PR https://github.com/integromat/imt-web-api/actions/runs/12408819849?pr=2637 shows us that backticks in PR title make some mess, allowing to "run" the backticked expressions. This should fix it